### PR TITLE
bug/launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,18 +16,18 @@
             android:label="@string/app_name"
             android:name=".ui.main.MainActivity"
             android:windowSoftInputMode="stateHidden"
-            android:theme="@style/AppTheme.NoActionBar"/>
-        <!-- GENERATOR - MORE ACTIVITIES -->
-
-        <activity-alias
-            android:name=".Launcher"
-            android:targetActivity=".ui.main.MainActivity">
+            android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
-        </activity-alias>
+        </activity>
+        <!-- GENERATOR - MORE ACTIVITIES -->
+
+        <activity-alias
+            android:name=".Launcher"
+            android:targetActivity=".ui.main.MainActivity"/>
 
         <meta-data
             android:name="com.crashlytics.ApiKey"


### PR DESCRIPTION
Fixes the following bug:
1. Open app
2. Press back until the app closes
3. Press the recent apps button

At this point, the app will fling off the screen and the process will be killed.  Of course, this is not desirable.  With the fix in place, the app will properly open.

I'm unsure why putting the intent filter inside the alias causes the bug.