### PR TITLE
Feature/jacoco

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ android {
     }
 
     testOptions {
-
+        execution 'ANDROID_TEST_ORCHESTRATOR'
         animationsDisabled true
 
         unitTests {
@@ -219,6 +219,9 @@ dependencies {
     androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
     androidTestImplementation 'com.github.fabioCollini:DaggerMock:0.8.4'
     androidTestImplementation 'com.linkedin.testbutler:test-butler-library:1.3.1'
+
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.2-alpha1'
+
 }
 
 task findbugs(type: FindBugs, dependsOn: "assembleDebug") {
@@ -259,8 +262,7 @@ task checkstyle(type: Checkstyle, dependsOn: "assembleDebug") {
     ]
 }
 
-
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest', 'createDevDebugCoverageReport']) {
 
     reports {
         xml.enabled = true
@@ -274,7 +276,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
     executionData = fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+            'jacoco/testDevDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
     ])
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,8 @@ buildscript {
 
         classpath 'io.fabric.tools:gradle:1.25.1'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
+        classpath 'org.jacoco:org.jacoco.core:0.8.0'
+
     }
 }
 
@@ -29,8 +31,17 @@ apply plugin: 'io.fabric'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
+apply plugin: 'jacoco'
 
 apply plugin: 'com.github.ben-manes.versions'
+
+jacoco {
+    toolVersion = '0.8.0'//this version needs to match the jacoco version in the root build.gradle
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
 
 android {
     compileOptions {
@@ -87,6 +98,7 @@ android {
         debug {
             minifyEnabled false
             shrinkResources false
+            testCoverageEnabled true
         }
 
         release {
@@ -107,6 +119,9 @@ android {
     }
 
     testOptions {
+        execution 'ANDROID_TEST_ORCHESTRATOR'
+        animationsDisabled true
+
         unitTests {
             includeAndroidResources = true
         }
@@ -243,6 +258,30 @@ task checkstyle(type: Checkstyle, dependsOn: "assembleDebug") {
     configProperties = [
             'checkstyle.cache.file': rootProject.file('build/checkstyle.cache'),
     ]
+}
+
+    // Our merge report task
+    // Borrowed from:
+    // https://proandroiddev.com/unified-code-coverage-for-android-revisited-44789c9b722f
+    // https://gist.github.com/rafaeltoledo/f3bc7f33ca5baa5f58d21579299ce46a/
+
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest', 'createDevDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDevDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ])
 }
 
 // Kotlin plugin for testing

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,6 @@ buildscript {
 
         classpath 'io.fabric.tools:gradle:1.25.1'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-        classpath 'org.jacoco:org.jacoco.core:0.8.0'
-
     }
 }
 
@@ -31,12 +29,13 @@ apply plugin: 'io.fabric'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
-apply plugin: 'jacoco'
 
 apply plugin: 'com.github.ben-manes.versions'
 
+apply plugin: 'jacoco'
+
 jacoco {
-    toolVersion = '0.8.0'//this version needs to match the jacoco version in the root build.gradle
+    toolVersion = '0.8.0'
 }
 
 tasks.withType(Test) {
@@ -98,7 +97,6 @@ android {
         debug {
             minifyEnabled false
             shrinkResources false
-            testCoverageEnabled true
         }
 
         release {
@@ -119,9 +117,6 @@ android {
     }
 
     testOptions {
-        execution 'ANDROID_TEST_ORCHESTRATOR'
-        animationsDisabled true
-
         unitTests {
             includeAndroidResources = true
         }
@@ -258,30 +253,6 @@ task checkstyle(type: Checkstyle, dependsOn: "assembleDebug") {
     configProperties = [
             'checkstyle.cache.file': rootProject.file('build/checkstyle.cache'),
     ]
-}
-
-    // Our merge report task
-    // Borrowed from:
-    // https://proandroiddev.com/unified-code-coverage-for-android-revisited-44789c9b722f
-    // https://gist.github.com/rafaeltoledo/f3bc7f33ca5baa5f58d21579299ce46a/
-
-
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest', 'createDevDebugCoverageReport']) {
-
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-
-    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
-    def mainSrc = "$project.projectDir/src/main/java"
-
-    sourceDirectories = files([mainSrc])
-    classDirectories = files([debugTree])
-    executionData = fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDevDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
-    ])
 }
 
 // Kotlin plugin for testing

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,7 @@ android {
         debug {
             minifyEnabled false
             shrinkResources false
+            testCoverageEnabled true
         }
 
         release {
@@ -117,6 +118,9 @@ android {
     }
 
     testOptions {
+
+        animationsDisabled true
+
         unitTests {
             includeAndroidResources = true
         }
@@ -253,6 +257,25 @@ task checkstyle(type: Checkstyle, dependsOn: "assembleDebug") {
     configProperties = [
             'checkstyle.cache.file': rootProject.file('build/checkstyle.cache'),
     ]
+}
+
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ])
 }
 
 // Kotlin plugin for testing

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -263,6 +263,7 @@ task checkstyle(type: Checkstyle, dependsOn: "assembleDebug") {
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest', 'createDevDebugCoverageReport']) {
+    //Jacoco test report task added from: https://proandroiddev.com/unified-code-coverage-for-android-revisited-44789c9b722f
 
     reports {
         xml.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.android_plugin_version = '3.0.1'
+    ext.android_plugin_version = '3.1.1'
     ext.kotlin_version = '1.2.21'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath "com.android.tools.build:gradle:$android_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
+        classpath 'org.jacoco:org.jacoco.core:0.8.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.android_plugin_version = '3.1.1'
+    ext.android_plugin_version = '3.0.1'
     ext.kotlin_version = '1.2.21'
 
     repositories {


### PR DESCRIPTION
Adding Jacoco thanks to this blog post: https://proandroiddev.com/unified-code-coverage-for-android-revisited-44789c9b722f

I basically just followed the instructions and copied their gradle changes.
The blog post adds Android Test Orchestrator and Jacoco 0.8.0. Hopefully Test Orchestrator doesn't conflict with any existing test runners in our app.
![jacoco](https://user-images.githubusercontent.com/6208902/38738762-f47fada0-3f00-11e8-8a83-1c6d6e42ac82.png)


To view code coverage report:
`$ ./gradlew jacocoTestReport`
`$ open ./app/build/reports/coverage/dev/debug/index.html`

Also, a note from the end of the blog post:
```
EDIT: There’s an open issue related to Orchestrator not generating the properly coverage data. Star the issue and follow it for updates!
```
Issue can be found here: https://issuetracker.google.com/issues/72758547

