### PR TITLE
AndroidX and other stuff

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,13 +129,14 @@ ext {
     // App dependency versions
     androidXVersion = '1.0.0-rc02'
     playServicesVersion = '15.0.1'
-    daggerVersion = '2.14.1'
+    daggerVersion = '2.17'
     retrofitVersion = '2.4.0'
     okHttpVersion = '3.11.0'
     leakcanaryVersion = '1.5.4'
 
     // Test dependency versions
-    mockitoVersion = '2.13.0'
+    mockitoVersion = '2.22.0'
+    mockitoKotlinVersion = '2.0.0-RC2'
     robolectricVersion = '3.7.1'
     androidTestSupportVersion = '1.0.1'
     espressoVersion = '3.0.2'
@@ -196,7 +197,7 @@ dependencies {
     // Unit test
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "org.robolectric:shadows-supportv4:$robolectricVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
@@ -208,7 +209,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-alpha4'
 
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
-    androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
+    androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"
     androidTestImplementation 'com.github.fabioCollini:DaggerMock:0.8.4'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ androidExtensions {
 
 ext {
     // App dependency versions
-    supportVersion = '27.1.1'
+    androidXVersion = '1.0.0-rc02'
     playServicesVersion = '15.0.1'
     daggerVersion = '2.14.1'
     retrofitVersion = '2.3.0'
@@ -146,13 +146,13 @@ dependencies {
     // Need this because of Kotlin
 
     // Android/Google libraries
-    implementation 'androidx.core:core-ktx:1.0.0-rc02'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2'
-    implementation 'androidx.appcompat:appcompat:1.0.0-rc02'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0-rc02'
-    implementation 'androidx.cardview:cardview:1.0.0-rc02'
-    implementation 'androidx.annotation:annotation:1.0.0-rc02'
-    implementation 'com.google.android.material:material:1.0.0-rc02'
+    implementation "androidx.core:core-ktx:$androidXVersion"
+    implementation "androidx.constraintlayout:constraintlayout:2.0.0-alpha2"
+    implementation "androidx.appcompat:appcompat:$androidXVersion"
+    implementation "androidx.recyclerview:recyclerview:$androidXVersion"
+    implementation "androidx.cardview:cardview:$androidXVersion"
+    implementation "androidx.annotation:annotation:$androidXVersion"
+    implementation "com.google.android.material:material:$androidXVersion"
 
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,19 +146,19 @@ dependencies {
     // Need this because of Kotlin
 
     // Android/Google libraries
-    implementation 'androidx.core:core-ktx:0.3'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation "com.android.support:appcompat-v7:$supportVersion"
-    implementation "com.android.support:recyclerview-v7:$supportVersion"
-    implementation "com.android.support:cardview-v7:$supportVersion"
-    implementation "com.android.support:support-annotations:$supportVersion"
-    implementation "com.android.support:design:$supportVersion"
+    implementation 'androidx.core:core-ktx:1.0.0-rc02'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2'
+    implementation 'androidx.appcompat:appcompat:1.0.0-rc02'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0-rc02'
+    implementation 'androidx.cardview:cardview:1.0.0-rc02'
+    implementation 'androidx.annotation:annotation:1.0.0-rc02'
+    implementation 'com.google.android.material:material:1.0.0-rc02'
 
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 
-    implementation "android.arch.lifecycle:runtime:1.1.1"
-    implementation "android.arch.lifecycle:extensions:1.1.1"
-    kapt "android.arch.lifecycle:compiler:1.1.1"
+    implementation "androidx.lifecycle:lifecycle-runtime:2.0.0-rc01"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.0.0-rc01"
+    kapt "androidx.lifecycle:lifecycle-compiler:2.0.0-rc01"
 
     // App architecture - Dagger 2
     implementation "com.google.dagger:dagger:$daggerVersion"
@@ -202,10 +202,10 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
 
     // Android JUnit Runner, JUnit Rules, and Espresso
-    androidTestImplementation "com.android.support.test:runner:$androidTestSupportVersion"
-    androidTestImplementation "com.android.support.test:rules:$androidTestSupportVersion"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
-    androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
+    androidTestImplementation 'androidx.test:runner:1.1.0-alpha4'
+    androidTestImplementation 'androidx.test:rules:1.1.0-alpha4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-alpha4'
 
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
     androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -143,7 +143,6 @@ ext {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    kapt "com.android.databinding:compiler:$rootProject.ext.android_plugin_version"
     // Need this because of Kotlin
 
     // Android/Google libraries

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,8 +130,8 @@ ext {
     androidXVersion = '1.0.0-rc02'
     playServicesVersion = '15.0.1'
     daggerVersion = '2.14.1'
-    retrofitVersion = '2.3.0'
-    okHttpVersion = '3.9.1'
+    retrofitVersion = '2.4.0'
+    okHttpVersion = '3.11.0'
     leakcanaryVersion = '1.5.4'
 
     // Test dependency versions
@@ -178,7 +178,7 @@ dependencies {
 
     // Networking - REST
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:2.3.0"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
     // Monitoring - Timber (logging)

--- a/app/src/androidTest/java/com/mycompany/myapp/CustomAppTestRunner.kt
+++ b/app/src/androidTest/java/com/mycompany/myapp/CustomAppTestRunner.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import android.app.KeyguardManager
 import android.content.Context
 import android.os.PowerManager
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnitRunner
+import androidx.test.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnitRunner
 
 class CustomAppTestRunner : AndroidJUnitRunner() {
     override fun onStart() {

--- a/app/src/androidTest/java/com/mycompany/myapp/RecyclerViewMatcher.kt
+++ b/app/src/androidTest/java/com/mycompany/myapp/RecyclerViewMatcher.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp
 
 import android.content.res.Resources
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 
 import org.hamcrest.Description

--- a/app/src/androidTest/java/com/mycompany/myapp/TestUtils.kt
+++ b/app/src/androidTest/java/com/mycompany/myapp/TestUtils.kt
@@ -1,6 +1,6 @@
 package com.mycompany.myapp
 
-import android.support.test.InstrumentationRegistry
+import androidx.test.InstrumentationRegistry
 import com.mycompany.myapp.app.MainApplication
 
 object TestUtils {

--- a/app/src/androidTest/java/com/mycompany/myapp/ui/main/MainActivityEspressoTest.kt
+++ b/app/src/androidTest/java/com/mycompany/myapp/ui/main/MainActivityEspressoTest.kt
@@ -16,8 +16,8 @@ import com.mycompany.myapp.data.api.github.model.Author
 import com.mycompany.myapp.data.api.github.model.Commit
 import com.mycompany.myapp.data.api.github.model.CommitDetails
 import com.mycompany.myapp.withRecyclerView
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Observable
 import org.hamcrest.Matchers.not
 import org.junit.Rule

--- a/app/src/androidTest/java/com/mycompany/myapp/ui/main/MainActivityEspressoTest.kt
+++ b/app/src/androidTest/java/com/mycompany/myapp/ui/main/MainActivityEspressoTest.kt
@@ -1,11 +1,11 @@
 package com.mycompany.myapp.ui.main
 
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.action.ViewActions.*
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.*
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import com.mycompany.myapp.EspressoMatchers.regex
 import com.mycompany.myapp.MainApplicationDaggerMockRule
 import com.mycompany.myapp.R

--- a/app/src/dev/java/com/mycompany/myapp/ui/VariantViewModelFactoryModule.kt
+++ b/app/src/dev/java/com/mycompany/myapp/ui/VariantViewModelFactoryModule.kt
@@ -1,6 +1,6 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.ViewModel
+import androidx.lifecycle.ViewModel
 import com.mycompany.myapp.ui.devsettings.DevSettingsViewModel
 import dagger.Binds
 import dagger.Module

--- a/app/src/dev/java/com/mycompany/myapp/ui/devsettings/DevSettingsActivity.kt
+++ b/app/src/dev/java/com/mycompany/myapp/ui/devsettings/DevSettingsActivity.kt
@@ -2,7 +2,7 @@ package com.mycompany.myapp.ui.devsettings
 
 import android.content.Context
 import android.content.Intent
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.os.Bundle
 import com.mycompany.myapp.R
 import com.mycompany.myapp.ui.BaseActivity

--- a/app/src/dev/java/com/mycompany/myapp/ui/devsettings/DevSettingsFragment.kt
+++ b/app/src/dev/java/com/mycompany/myapp/ui/devsettings/DevSettingsFragment.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.ui.devsettings
 
 import android.content.Context
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/dev/java/com/mycompany/myapp/ui/devsettings/DevSettingsViewModel.kt
+++ b/app/src/dev/java/com/mycompany/myapp/ui/devsettings/DevSettingsViewModel.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.ui.devsettings
 
 import android.app.Application
-import android.databinding.Bindable
+import androidx.databinding.Bindable
 import android.os.Parcelable
 import com.mycompany.myapp.BR
 import com.mycompany.myapp.app.Settings

--- a/app/src/dev/res/layout/activity_dev_settings.xml
+++ b/app/src/dev/res/layout/activity_dev_settings.xml
@@ -9,28 +9,28 @@
             type="com.mycompany.myapp.ui.devsettings.DevSettingsViewModel"/>
     </data>
 
-    <android.support.design.widget.CoordinatorLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/root_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
 
-        <android.support.design.widget.AppBarLayout
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/AppTheme.AppBarOverlay">
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize"
                 android:background="?android:attr/colorPrimary"
                 app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-        </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <include layout="@layout/content_dev_settings"/>
 
-    </android.support.design.widget.CoordinatorLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
 </layout>

--- a/app/src/dev/res/layout/fragment_dev_settings.xml
+++ b/app/src/dev/res/layout/fragment_dev_settings.xml
@@ -10,11 +10,11 @@
             type="com.mycompany.myapp.ui.devsettings.DevSettingsViewModel"/>
     </data>
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <android.support.design.widget.TextInputLayout
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -33,7 +33,7 @@
                 android:text="@={vm.baseUrl}"
                 android:inputType="textUri"/>
 
-        </android.support.design.widget.TextInputLayout>
+        </com.google.android.material.textfield.TextInputLayout>
 
         <CheckBox
             android:id="@+id/trust_all_ssl"
@@ -61,6 +61,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/trust_all_ssl"/>
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/app/src/main/java/com/mycompany/myapp/app/MainApplication.kt
+++ b/app/src/main/java/com/mycompany/myapp/app/MainApplication.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.app
 
 import android.app.Application
-import android.support.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting
 
 import javax.inject.Inject
 

--- a/app/src/main/java/com/mycompany/myapp/ui/BaseActivity.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/BaseActivity.kt
@@ -1,9 +1,9 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.ViewModel
-import android.arch.lifecycle.ViewModelProvider
-import android.arch.lifecycle.ViewModelProviders
-import android.support.v7.app.AppCompatActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import androidx.appcompat.app.AppCompatActivity
 import com.mycompany.myapp.app.ApplicationComponent
 import com.mycompany.myapp.app.MainApplication
 import javax.inject.Inject

--- a/app/src/main/java/com/mycompany/myapp/ui/BaseFragment.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/BaseFragment.kt
@@ -1,8 +1,8 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.ViewModel
-import android.arch.lifecycle.ViewModelProviders
-import android.support.v4.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProviders
+import androidx.fragment.app.Fragment
 import kotlin.reflect.KClass
 
 abstract class BaseFragment: Fragment() {

--- a/app/src/main/java/com/mycompany/myapp/ui/BaseViewModel.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/BaseViewModel.kt
@@ -1,9 +1,9 @@
 package com.mycompany.myapp.ui
 
 import android.app.Application
-import android.arch.lifecycle.AndroidViewModel
-import android.databinding.Observable
-import android.databinding.PropertyChangeRegistry
+import androidx.lifecycle.AndroidViewModel
+import androidx.databinding.Observable
+import androidx.databinding.PropertyChangeRegistry
 import android.os.Bundle
 import android.os.Parcelable
 import io.reactivex.disposables.CompositeDisposable

--- a/app/src/main/java/com/mycompany/myapp/ui/DaggerViewModelFactory.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/DaggerViewModelFactory.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.ViewModel
-import android.arch.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton

--- a/app/src/main/java/com/mycompany/myapp/ui/SimpleSnackbarMessage.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/SimpleSnackbarMessage.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.LifecycleOwner
-import android.arch.lifecycle.Observer
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
 
 /**
  * A SingleLiveEvent used for Snackbar messages. Like a [SingleLiveEvent] but also prevents

--- a/app/src/main/java/com/mycompany/myapp/ui/SingleLiveEvent.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/SingleLiveEvent.kt
@@ -1,10 +1,9 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.LifecycleOwner
-import android.arch.lifecycle.MutableLiveData
-import android.arch.lifecycle.Observer
-import android.support.annotation.MainThread
-import android.util.Log
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import androidx.annotation.MainThread
 import timber.log.Timber
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -23,7 +22,7 @@ open class SingleLiveEvent<T> : MutableLiveData<T>() {
     private val pending = AtomicBoolean(false)
 
     @MainThread
-    override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
+    override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
         if (hasActiveObservers()) {
             Timber.w("Multiple observers registered but only one will be notified of changes.")
         }

--- a/app/src/main/java/com/mycompany/myapp/ui/ViewModelFactoryModule.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/ViewModelFactoryModule.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.ViewModel
-import android.arch.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.mycompany.myapp.ui.main.MainViewModel
 // GENERATOR - MORE IMPORTS //
 import dagger.Binds

--- a/app/src/main/java/com/mycompany/myapp/ui/ViewModelKey.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/ViewModelKey.kt
@@ -1,6 +1,6 @@
 package com.mycompany.myapp.ui
 
-import android.arch.lifecycle.ViewModel
+import androidx.lifecycle.ViewModel
 import dagger.MapKey
 import kotlin.reflect.KClass
 

--- a/app/src/main/java/com/mycompany/myapp/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/main/MainActivity.kt
@@ -1,8 +1,8 @@
 package com.mycompany.myapp.ui.main
 
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.os.Bundle
-import android.support.design.widget.Snackbar
+import com.google.android.material.snackbar.Snackbar
 import com.mycompany.myapp.R
 import com.mycompany.myapp.ui.BaseActivity
 import com.mycompany.myapp.ui.SimpleSnackbarMessage

--- a/app/src/main/java/com/mycompany/myapp/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/main/MainFragment.kt
@@ -1,10 +1,10 @@
 package com.mycompany.myapp.ui.main
 
 import android.content.Context
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.os.Bundle
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/mycompany/myapp/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/mycompany/myapp/ui/main/MainViewModel.kt
@@ -1,9 +1,9 @@
 package com.mycompany.myapp.ui.main
 
 import android.app.Application
-import android.databinding.Bindable
+import androidx.databinding.Bindable
 import android.os.Parcelable
-import android.support.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting
 import com.mycompany.myapp.BR
 import com.mycompany.myapp.BuildConfig
 import com.mycompany.myapp.R

--- a/app/src/main/java/com/mycompany/myapp/util/databinding/RecyclerViewAdapters.kt
+++ b/app/src/main/java/com/mycompany/myapp/util/databinding/RecyclerViewAdapters.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.util.databinding
 
-import android.databinding.BindingAdapter
-import android.support.v7.widget.RecyclerView
+import androidx.databinding.BindingAdapter
+import androidx.recyclerview.widget.RecyclerView
 
 import com.mycompany.myapp.util.recyclerview.ArrayAdapter
 

--- a/app/src/main/java/com/mycompany/myapp/util/databinding/ViewAdapters.kt
+++ b/app/src/main/java/com/mycompany/myapp/util/databinding/ViewAdapters.kt
@@ -1,6 +1,6 @@
 package com.mycompany.myapp.util.databinding
 
-import android.databinding.BindingAdapter
+import androidx.databinding.BindingAdapter
 import android.view.View
 
 object ViewAdapters {

--- a/app/src/main/java/com/mycompany/myapp/util/progress/TestableProgressBar.kt
+++ b/app/src/main/java/com/mycompany/myapp/util/progress/TestableProgressBar.kt
@@ -2,8 +2,8 @@ package com.mycompany.myapp.util.progress
 
 import android.content.Context
 import android.os.Build.VERSION_CODES
-import android.support.annotation.RequiresApi
-import android.support.v4.content.ContextCompat
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
 import android.util.AttributeSet
 import android.widget.ProgressBar
 import com.mycompany.myapp.R

--- a/app/src/main/java/com/mycompany/myapp/util/recyclerview/ArrayAdapter.kt
+++ b/app/src/main/java/com/mycompany/myapp/util/recyclerview/ArrayAdapter.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp.util.recyclerview
 
-import android.support.v7.widget.RecyclerView
-import android.support.v7.widget.RecyclerView.ViewHolder
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import java.util.*
 
 abstract class ArrayAdapter<Item, ItemViewHolder : ViewHolder> : RecyclerView.Adapter<ItemViewHolder>() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,27 +8,27 @@
             type="com.mycompany.myapp.ui.main.MainViewModel"/>
     </data>
 
-    <android.support.design.widget.CoordinatorLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/root_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
 
-        <android.support.design.widget.AppBarLayout
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/AppTheme.AppBarOverlay">
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize"
                 android:background="?android:attr/colorPrimary"
                 app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-        </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <include layout="@layout/content_main"/>
 
-    </android.support.design.widget.CoordinatorLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -10,7 +10,7 @@
             type="com.mycompany.myapp.ui.main.MainViewModel"/>
     </data>
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -25,7 +25,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
@@ -40,9 +40,9 @@
                     android:text="@={vm.username}"
                     android:inputType="text"/>
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
@@ -57,7 +57,7 @@
                     android:text="@={vm.repository}"
                     android:inputType="text"/>
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <Button
                 android:id="@+id/fetch_commits"
@@ -73,7 +73,7 @@
 
         </LinearLayout>
 
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/footer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -109,9 +109,9 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 android:text="@{@string/fingerprint_format(vm.fingerprint)}"/>
 
-        </android.support.constraint.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/commits"
             android:layout_width="0dp"
             android:layout_height="0dp"
@@ -135,6 +135,6 @@
             app:layout_constraintTop_toBottomOf="@+id/header"
             app:visible="@{vm.loading}"/>
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/app/src/main/res/layout/item_commit_summary.xml
+++ b/app/src/main/res/layout/item_commit_summary.xml
@@ -10,7 +10,7 @@
             type="com.mycompany.myapp.data.api.github.model.Commit"/>
     </data>
 
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
@@ -20,7 +20,7 @@
         android:layout_marginTop="8dp"
         app:cardCornerRadius="4dp">
 
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
@@ -54,7 +54,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/message"/>
 
-        </android.support.constraint.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </android.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 </layout>

--- a/app/src/test/java/com/mycompany/myapp/SimpleTests.kt
+++ b/app/src/test/java/com/mycompany/myapp/SimpleTests.kt
@@ -1,7 +1,7 @@
 package com.mycompany.myapp
 
 import android.os.Bundle
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/app/src/test/java/com/mycompany/myapp/data/api/github/GitHubInteractorTest.kt
+++ b/app/src/test/java/com/mycompany/myapp/data/api/github/GitHubInteractorTest.kt
@@ -3,7 +3,7 @@ package com.mycompany.myapp.data.api.github
 import com.mycompany.myapp.data.api.github.GitHubInteractor.LoadCommitsRequest
 import com.mycompany.myapp.data.api.github.GitHubInteractor.LoadCommitsResponse
 import com.mycompany.myapp.data.api.github.model.CommitTestHelper.stubCommit
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/mycompany/myapp/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/mycompany/myapp/ui/main/MainViewModelTest.kt
@@ -3,8 +3,8 @@ package com.mycompany.myapp.ui.main
 import com.mycompany.myapp.TrampolineSchedulerRule
 import com.mycompany.myapp.data.api.github.GitHubInteractor
 import com.mycompany.myapp.data.api.github.model.Commit
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Observable
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/app/templates/screen/Activity.kt.mustache
+++ b/app/templates/screen/Activity.kt.mustache
@@ -2,7 +2,7 @@ package {{package}}.ui.{{screenLowerCase}}
 
 import android.content.Context
 import android.content.Intent
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.os.Bundle
 
 import {{package}}.R

--- a/app/templates/screen/ActivityTests.kt.mustache
+++ b/app/templates/screen/ActivityTests.kt.mustache
@@ -1,7 +1,7 @@
 package {{package}}.ui.{{screenLowerCase}}
 
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import {{package}}.MainApplicationDaggerMockRule
 
 import org.junit.Rule

--- a/app/templates/screen/Fragment.kt.mustache
+++ b/app/templates/screen/Fragment.kt.mustache
@@ -1,7 +1,7 @@
 package {{package}}.ui.{{screenLowerCase}}
 
 import android.content.Context
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/app/templates/screen/activity.xml.mustache
+++ b/app/templates/screen/activity.xml.mustache
@@ -14,7 +14,7 @@
             android:layout_height="match_parent"
             android:fitsSystemWindows="true">
 
-        <android.support.design.widget.AppBarLayout
+        <com.google.android.material.appbar.AppBarLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:theme="@style/AppTheme.AppBarOverlay">
@@ -26,7 +26,7 @@
                     android:background="?android:attr/colorPrimary"
                     app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-        </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <include layout="@layout/content_{{screenUnderscore}}"/>
 

--- a/app/templates/screen/activity.xml.mustache
+++ b/app/templates/screen/activity.xml.mustache
@@ -8,7 +8,7 @@
                 type="{{package}}.ui.{{screenLowerCase}}.{{screenUpperCamel}}ViewModel"/>
     </data>
 
-    <android.support.design.widget.CoordinatorLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/root_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -19,7 +19,7 @@
                 android:layout_height="wrap_content"
                 android:theme="@style/AppTheme.AppBarOverlay">
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="?android:attr/actionBarSize"
@@ -30,5 +30,5 @@
 
         <include layout="@layout/content_{{screenUnderscore}}"/>
 
-    </android.support.design.widget.CoordinatorLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/templates/screen/fragment.xml.mustache
+++ b/app/templates/screen/fragment.xml.mustache
@@ -10,10 +10,10 @@
                 type="{{package}}.ui.{{screenLowerCase}}.{{screenUpperCamel}}ViewModel"/>
     </data>
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.android_plugin_version = '3.1.2'
-    ext.kotlin_version = '1.2.41'
+    ext.android_plugin_version = '3.2.0-rc03'
+    ext.kotlin_version = '1.2.61'
     ext.jacoco_version = '0.8.1'
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,5 @@ org.gradle.caching=true
 android.enableBuildCache=true
 
 org.gradle.warning.mode=summary
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
~#### Note: You will need Android Studio Preview 3.2 RC3 or later to view this PR~
Actually, it _does_ work in the current version of Android Studio (3.1.4)

Major stuff that changed:
1) Updated Android Gradle Plugin to `3.2.0-rc03` as this was a prerequisite for migrating to AndroidX libraries. Also updated Kotlin to `1.2.61`
2) Ran the migration assistant to move gradle dependencies over to AndroidX. Also updated gradle environment variable from `supportVersion` to `androidXVersion`
2.1) Made a small (required) change to the method signature for `observe()` method in `SingleLiveEvent.kt` after updating to AndroidX
3) Updated other libraries while I was in there. `Dagger, Retrofit, OkHttp, Mockito, MockitoKotlin`
4) The dev who runs MockitoKotlin actually changed the package name for the project... so I went through the `test` and `androidTest` folders and updated the package name in the imports. Hopefully I didn't screw anything up, lol
5) Updated `.mustache` files for generating screens
    Verify using this: `./gradlew app:screen -Ppackage=com.mycompany.myapp -Pscreen=Lmao`
6) <b>Yes, I did run ~all~ some of the tests to make sure they pass.</b>